### PR TITLE
Add link to script page in edit summaries

### DIFF
--- a/info.js
+++ b/info.js
@@ -188,7 +188,7 @@ wikiEditor.info = { // API
                 "format": "json",
                 "token" : mw.user.tokens.get("csrfToken"),
                 "title" : "User_talk:"+ user,
-                "summary" : summary + " (RedWarn)", // summary sign here
+                "summary" : summary + " ([[User:JamesHSmith6789/redwarn|RedWarn]])", // summary sign here
                 "text": finalTxt
             }).done(dt => {
                 // We done. Check for errors, then callback appropriately

--- a/ui.js
+++ b/ui.js
@@ -258,7 +258,7 @@ wikiEditor.ui = {
                             "format": "json",
                             "token" : mw.user.tokens.get("csrfToken"),
                             "title" : mw.config.get("wgRelevantPageName"),
-                            "summary" : "Void notice made in error (RedWarn)", // summary sign here
+                            "summary" : "Void notice made in error ([[User:JamesHSmith6789/redwarn|RedWarn]])", // summary sign here
                             "text": finalStr
                         }).done(dt => {
                             // We done. Check for errors, then callback appropriately


### PR DESCRIPTION
By Wikipedia user script convention, the (Script Name) at the end of edit summaries is usually a link to the documentation page for the script.

Thanks for writing this, by the way! Looking forward to testing it out.