### PR TITLE
rollback.js: Use mw-undo tag rather than undo

### DIFF
--- a/rollback.js
+++ b/rollback.js
@@ -47,7 +47,7 @@ wikiEditor.rollback = { // Rollback features
                     "title" : mw.config.get("wgRelevantPageName"),
                     "summary" : summary + ": " + reason + " [[WP:REDWARN|(RedWarn)]]", // summary sign here
                     "text": content,
-                    "tags": "undo" // Tag with undo flag
+                    "tags": "mw-undo" // Tag with undo flag
                 }).done(dt => {
                     // We done. Check for errors, then callback appropriately
                     if (!dt.edit) {


### PR DESCRIPTION
`mw-undo` is the one defined by the software, using `undo` is almost certainly a mistake.  That built-in `mw-undo` isn't something that can be used, however.  This tag (`undo`) was created a year ago for some unknown reason.  I don't know why or what it existed for, but AFAICT *only* redwarn is using it, so it isn't quite helpful in the same way.

As such, this PR will currently just break things.  If the goal is to have edits tagged as "undo", I'd recommend using the API rather than this bespoke and otherwise-unused tag: you can use the `undo` and `undoafter` parameters.  Otherwise, this should be removed.